### PR TITLE
Fixing the error for file size of 0kb

### DIFF
--- a/tasks/json-minify.js
+++ b/tasks/json-minify.js
@@ -25,6 +25,11 @@ module.exports = function(grunt) {
       var data = grunt.file.read(filepath);
       var compressed;
 
+      if(!data.length){
+          grunt.log.writeln('Skipping File "' + filepath + '" 0kb size');
+          return;
+      }
+
       try {
         compressed = JSON5.stringify(JSON5.parse(data));
       } catch (err) {


### PR DESCRIPTION
What?

Fixed the below error for file size 0kb

```
Running "json-minify:build" (json-minify) task
{
Warning: Unexpected '' Use --force to continue.

Aborted due to warnings.
```

What to test?
Add a 0kb json file and run grunt task

```
Running "json-minify:build" (json-minify) task
File "app/de.json" 0KB..: skipping

Total compressed: 1 files
>> 0 KiB - NaN% = 0 KiB

Done, without errors.
```
