### PR TITLE
Adding support for duplicate_keys.

### DIFF
--- a/grunt.js
+++ b/grunt.js
@@ -1,9 +1,12 @@
 module.exports = function(grunt) {
-
+  grunt.loadNpmTasks('grunt-contrib-jshint');
+    
   // Project configuration.
   grunt.initConfig({
-    lint: {
-      files: ['grunt.js', 'tasks/**/*.js']
+    jshint: {
+        code: {
+        src: ['tasks/**/*.js']
+      }
     },
     watch: {
       files: '<config:lint.files>',
@@ -33,5 +36,5 @@ module.exports = function(grunt) {
   grunt.loadTasks('tasks');
 
   // Default task.
-  grunt.registerTask('default', 'lint');
+  grunt.registerTask('default', 'jshint');
 };

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "gruntplugin"
   ],
   "dependencies": {
+    "grunt-contrib-jshint": "^1.0.0",
     "json5": "~0.2.0"
   }
 }

--- a/tasks/json-minify.js
+++ b/tasks/json-minify.js
@@ -7,41 +7,53 @@
  */
 var JSON5 = require('json5');
 
-module.exports = function(grunt) {
-  grunt.registerMultiTask('json-minify', 'JSON minification task', function() {
-    var totalInBytes = 0;
-    var totalOutBytes = 0;
-    var totalProfitPercents = 0;
-    var files = grunt.file.expand(this.data.files);
+module.exports = function (grunt) {
+    grunt.registerMultiTask('json-minify', 'JSON minification task', function () {
+        var totalInBytes = 0;
+        var totalOutBytes = 0;
+        var totalProfitPercents = 0;
+        var files = grunt.file.expand(this.data.files);
+        var duplicate_keys = this.data.duplicate_keys;
 
-    function calcCompression(inBytes, outBytes) {
-      var profitPercents = 100 - outBytes * 100 / inBytes;
-      return (Math.round((inBytes / 1024) * 1000) / 1000) + ' KiB - ' +
-        ((Math.round(profitPercents * 10) / 10) + '%').green + ' = ' +
-        (Math.round((outBytes / 1024) * 1000) / 1000) + ' KiB';
-    }
+        function calcCompression(inBytes, outBytes) {
+            var profitPercents = 100 - outBytes * 100 / inBytes;
+            return (Math.round((inBytes / 1024) * 1000) / 1000) + ' KiB - ' +
+                ((Math.round(profitPercents * 10) / 10) + '%').green + ' = ' +
+                (Math.round((outBytes / 1024) * 1000) / 1000) + ' KiB';
+        }
 
-    files.forEach(function(filepath) {
-      var data = grunt.file.read(filepath);
-      var compressed;
+        files.forEach(function (filepath) {
+            var data = grunt.file.read(filepath);
+            var compressed;
 
-      try {
-        compressed = JSON5.stringify(JSON5.parse(data));
-      } catch (err) {
-        grunt.fail.warn(err);
-      }
+            if (!data.length) {
+                grunt.log.writeln('Skipping File "' + filepath + '" 0kb size');
+                return;
+            }
 
-      grunt.file.write(filepath, compressed);
+            try {
+                if (duplicate_keys !== undefined) {
+                    compressed = JSON5.stringify(JSON5.parse(data, {
+                        duplicate_keys: duplicate_keys
+                    }));
+                } else {
+                    compressed = JSON5.stringify(JSON5.parse(data));
+                }
+            } catch (err) {
+                grunt.fail.warn(err);
+            }
 
-      // and print profit info
-      grunt.verbose.writeln('File "' + filepath + '":');
-      grunt.verbose.ok(calcCompression(data.length, compressed.length));
+            grunt.file.write(filepath, compressed);
 
-      totalInBytes += data.length;
-      totalOutBytes += compressed.length;
+            // and print profit info
+            grunt.verbose.writeln('File "' + filepath + '":');
+            grunt.verbose.ok(calcCompression(data.length, compressed.length));
+
+            totalInBytes += data.length;
+            totalOutBytes += compressed.length;
+        });
+
+        grunt.log.writeln('\nTotal compressed: ' + files.length + ' files');
+        grunt.log.ok(calcCompression(totalInBytes, totalOutBytes));
     });
-
-    grunt.log.writeln('\nTotal compressed: ' + files.length + ' files');
-    grunt.log.ok(calcCompression(totalInBytes, totalOutBytes));
-  });
 };


### PR DESCRIPTION
Adding support for duplicate_keys, and updating lint to jshint to support later versions of grunt.

**Example usage:**

`build: {
                files: 'build/**/*.json',
                duplicate_keys: 'ignore'
            }`
