### PR TITLE
BREAKING CHANGE: Update files param to handle multiple directories

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -28,10 +28,10 @@ module.exports = function(grunt) {
 
     'json-minify': {
       default_options: {
-        files: '.tmp/default_options.json'
+        fileList: ['.tmp/default_options.json']
       },
       duplicate_keys: {
-        files: '.tmp/duplicate_keys.json'
+        fileList: ['.tmp/duplicate_keys.json']
       },
       custom_transform: {
         options: {
@@ -39,13 +39,13 @@ module.exports = function(grunt) {
             return JSON5.stringify(JSON5.parse(data));
           }
         },
-        files: '.tmp/custom_transform.json'
+        fileList: ['.tmp/custom_transform.json']
       },
       empty_file: {
         options: {
           skipOnError: true
         },
-        files: '.tmp/empty_file.json'
+        fileList: ['.tmp/empty_file.json']
       }
     },
 

--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ grunt.loadNpmTasks('grunt-json-minify');
 
 ## Usage
 
-Set the `files` parameter to the directory you want to minify. The minification is inplace, so you want to copy the data to the destination before you minify.
+Set the `fileList` parameter to the directory you want to minify. The minification is inplace, so you want to copy the data to the destination before you minify.
 
 Example:
 
 ```js
 'json-minify': {
   build: {
-    files: 'build/**/*.json'
+    fileList: ['build/**/*.json']
   }
 }
 ```
@@ -53,7 +53,7 @@ If you want to use your own minification algorithm you can overwrite the default
     }
   },
   build: {
-    files: 'build/**/*.json'
+    fileList: 'build/**/*.json'
   }
 }
 ```

--- a/tasks/json-minify.js
+++ b/tasks/json-minify.js
@@ -10,7 +10,7 @@
 
 module.exports = function(grunt) {
   grunt.registerMultiTask('json-minify', 'JSON minification task', function() {
-    const files = grunt.file.expand(this.data.files);
+    const files = grunt.file.expand(this.data.fileList);
     const options = this.options({
       skipOnError: false,
       encoding: undefined,


### PR DESCRIPTION
``` javascript
'json-minify': {
    build: {
        files: ['../../../foo/**/*.json', '../../../bar/*.json']
    }
},
```

produces an error
`Warning: Cannot use 'in' operator to search for 'src' in ../../../foo/**/*.json Use --force to continue.`

it would appear that `files` is attempting to do something that we dont want. Changing the name to `fileList` solves this problem.

Currently i can find no documentation for what `files` is attempting to do, nor can i find a way to backwards compatible-ize as the error is thrown before the task is run.
